### PR TITLE
Do not require attribute hash at initialization

### DIFF
--- a/lib/entasis/model.rb
+++ b/lib/entasis/model.rb
@@ -25,7 +25,7 @@ module Entasis
     #
     # Takes a hash and assigns keys and values to it's attributes members
     #
-    def initialize(hash)
+    def initialize(hash={})
       self.attributes = hash
     end
 

--- a/spec/entasis_spec.rb
+++ b/spec/entasis_spec.rb
@@ -15,6 +15,10 @@ describe "Entasis::Model" do
         Person.new(undefined: 'value')
       }.to raise_error Person::UnknownAttributeError, 'unkown attribute: undefined'
     end
+
+    it "does not require attribute hash" do
+      expect { Person.new }.to_not raise_error
+    end
   end
 
   describe "#attribute_names" do


### PR DESCRIPTION
This works more like ActiveRecord::Base models, which allows `Person.new`, rather than requiring `Person.new({})`
